### PR TITLE
feat: Add configurable NFS export name

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,7 @@ pub struct RPCContext {
     pub auth: crate::rpc::auth_unix,
     pub vfs: Arc<dyn NFSFileSystem + Send + Sync>,
     pub mount_signal: Option<mpsc::Sender<bool>>,
+    pub export_name: Arc<String>,
 }
 
 impl fmt::Debug for RPCContext {


### PR DESCRIPTION
Allow setting an optional export name. If provided, the NFS export path will be `/{name}` instead of the default `/`.