### PR TITLE
feat: Add configurable NFS export name

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -11,6 +11,7 @@ pub struct RPCContext {
     pub auth: crate::rpc::auth_unix,
     pub vfs: Arc<dyn NFSFileSystem + Send + Sync>,
     pub mount_signal: Option<mpsc::Sender<bool>>,
+    pub export_name: Arc<String>,
     pub transaction_tracker: Arc<TransactionTracker>,
 }
 

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -19,6 +19,7 @@ pub struct NFSTcpListener<T: NFSFileSystem + Send + Sync + 'static> {
     port: u16,
     arcfs: Arc<T>,
     mount_signal: Option<mpsc::Sender<bool>>,
+    export_name: Arc<String>,
     transaction_tracker: Arc<TransactionTracker>,
 }
 
@@ -167,8 +168,25 @@ impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcpListener<T> {
             port,
             arcfs,
             mount_signal: None,
+            export_name: Arc::from("/".to_string()),
             transaction_tracker: Arc::new(TransactionTracker::new(Duration::from_secs(60))),
         })
+    }
+
+    /// Sets an optional NFS export name.
+    ///
+    /// - `export_name`: The desired export name without slashes.
+    ///
+    /// Example: Name `foo` results in the export path `/foo`.
+    /// Default path is `/` if not set.
+    pub fn with_export_name<S: AsRef<str>>(&mut self, export_name: S) {
+        self.export_name = Arc::new(format!(
+            "/{}",
+            export_name
+                .as_ref()
+                .trim_end_matches('/')
+                .trim_start_matches('/')
+        ))
     }
 }
 
@@ -201,6 +219,7 @@ impl<T: NFSFileSystem + Send + Sync + 'static> NFSTcp for NFSTcpListener<T> {
                 auth: crate::rpc::auth_unix::default(),
                 vfs: self.arcfs.clone(),
                 mount_signal: self.mount_signal.clone(),
+                export_name: self.export_name.clone(),
                 transaction_tracker: self.transaction_tracker.clone(),
             };
             info!("Accepting connection from {}", context.client_addr);


### PR DESCRIPTION
Allow setting an optional export name. If provided, the NFS export path will be `/{name}` instead of the default `/`.